### PR TITLE
Question about the Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ necessary environment variables and aliases.
 
 - **ttf-ms-fonts** (windows fonts, for better compatibility)
 - **powerline-fonts-git**
+


### PR DESCRIPTION
Hi,

sorry for this "fake" pull request. I found no other way in your repo to contact you.

I find your approach of making non XDG applications XDG aware by setting ENV variables very interesting. I only wonder how the Variables are set for applications started by i3 or dmenu. If I see it correctly you set them in .zshrc. To test this I added 'export TESTVARIABLE="is set"' to my .zshrc. Then I added 'bindsym $mod+F9 exec "env > /tmp/directenv"' to my I3 config. When I press $mod+F9 the file /tmp/directenv does not contain the TESTVARIABLE.

How is your setup to set the variables so that they are availabe for application started by i3?

Kind regards Clemens